### PR TITLE
Fix column name in the tutorial

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,4 @@
+[default.extend-words]
+# Allow dataset-specific column names from Hillstrom dataset
+womens = "womens"
+mens = "mens"

--- a/docs/source/tutorials/hillstrom.rst
+++ b/docs/source/tutorials/hillstrom.rst
@@ -44,7 +44,7 @@ Data Setup and Loading
         'history': df['history'],
         'history_segment': df['history_segment'].map(lambda s: int(s[0])),
         'mens': df['mens'],
-        'women': df['women'],
+        'womens': df['womens'],
         'zip_code': df['zip_code'].map(zip_code_mapping),
         'newbie': df['newbie'],
         'channel': df['channel'].map(channel_mapping)


### PR DESCRIPTION
Allow to use `womens` in typos.