### PR TITLE
Remove CyberAgent affiliation from Tomu Hirata

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -11,7 +11,7 @@ authors:
   - name: Tomu Hirata
     orcid: 0009-0006-3140-291X
     corresponding: true
-    affiliation: "1, 3"
+    affiliation: 3
   - name: Undral Byambadalai
     affiliation: 1
   - name: Tatsushi Oka


### PR DESCRIPTION
## Summary
- Update Tomu Hirata's affiliation from `"1, 3"` (CyberAgent + Databricks) to `3` (Databricks only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)