### PR TITLE
add QTE support for covariate adaptive randomization

### DIFF
--- a/dte_adj/base.py
+++ b/dte_adj/base.py
@@ -180,6 +180,11 @@ class DistributionEstimatorBase(ABC):
         into how treatment affects different parts of the outcome distribution. For stratified
         estimators, the computation properly accounts for strata.
 
+        Variance is estimated by stratified bootstrap: indices are resampled with replacement
+        within each stratum independently, which preserves per-stratum sample sizes and reflects
+        the covariate-adaptive randomization (CAR) design. For estimators without strata
+        (single stratum), this degenerates to a plain bootstrap.
+
         Args:
             target_treatment_arm (int): The index of the treatment arm of the treatment group.
             control_treatment_arm (int): The index of the treatment arm of the control group.
@@ -236,15 +241,23 @@ class DistributionEstimatorBase(ABC):
             self.outcomes,
             self.strata,
         )
-        n_obs = len(self.outcomes)
-        indexes = np.arange(n_obs)
+
+        # Precompute stratum indices for stratified bootstrap.
+        # When there is a single stratum this is equivalent to plain bootstrap.
+        unique_strata = np.unique(self.strata)
+        strata_indices = [np.where(self.strata == s)[0] for s in unique_strata]
 
         qtes = np.zeros((n_bootstrap, qte.shape[0]))
         bootstrap_iter = range(n_bootstrap)
         if display_progress:
             bootstrap_iter = tqdm(bootstrap_iter, desc="Bootstrap QTE")
         for b in bootstrap_iter:
-            bootstrap_indexes = np.random.choice(indexes, size=n_obs, replace=True)
+            bootstrap_indexes = np.concatenate(
+                [
+                    np.random.choice(idx, size=len(idx), replace=True)
+                    for idx in strata_indices
+                ]
+            )
 
             qtes[b] = self._compute_qtes(
                 target_treatment_arm,

--- a/dte_adj/base.py
+++ b/dte_adj/base.py
@@ -222,6 +222,11 @@ class DistributionEstimatorBase(ABC):
                 print(f"QTE at quantiles {quantiles}: {qte}")
                 print(f"Median effect (50th percentile): {qte[1]:.3f}")
         """
+        if quantiles is None:
+            quantiles = np.arange(1, 10) / 10
+        if np.any((quantiles <= 0) | (quantiles >= 1)):
+            raise ValueError("quantiles must be in the open interval (0, 1)")
+
         qte = self._compute_qtes(
             target_treatment_arm,
             control_treatment_arm,

--- a/dte_adj/stratified.py
+++ b/dte_adj/stratified.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import numpy as np
-from typing import Optional, Tuple, Any
+from typing import Tuple, Any
 from copy import deepcopy
-from scipy.stats import norm
 from tqdm.auto import tqdm
 from dte_adj.base import DistributionEstimatorBase
 from dte_adj.util import ArrayLike, _convert_to_ndarray
@@ -153,82 +152,6 @@ class SimpleStratifiedDistributionEstimator(DistributionEstimatorBase):
             prediction[:, 1:] - prediction[:, :-1],
             conditional_prediction[:, 1:] - conditional_prediction[:, :-1],
         )
-
-    def predict_qte(
-        self,
-        target_treatment_arm: int,
-        control_treatment_arm: int,
-        quantiles: Optional[np.ndarray] = None,
-        alpha: float = 0.05,
-        n_bootstrap=500,
-        display_progress: bool = True,
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """
-        Compute Quantile Treatment Effects (QTE) using stratified bootstrap.
-
-        Uses stratified bootstrap (resampling independently within each stratum) to
-        correctly estimate variance under covariate adaptive randomization (CAR).
-
-        Args:
-            target_treatment_arm (int): The index of the treatment arm of the treatment group.
-            control_treatment_arm (int): The index of the treatment arm of the control group.
-            quantiles (np.ndarray, optional): Quantiles used for QTE. Defaults to [0.1, 0.2, ..., 0.9].
-            alpha (float, optional): Significance level of the confidence bound. Defaults to 0.05.
-            n_bootstrap (int, optional): Number of bootstrap samples. Defaults to 500.
-            display_progress (bool, optional): Whether to display a progress bar. Defaults to True.
-
-        Returns:
-            Tuple[np.ndarray, np.ndarray, np.ndarray]: A tuple containing:
-                - Expected QTEs (np.ndarray): Treatment effect estimates at each quantile
-                - Lower bounds (np.ndarray): Lower confidence interval bounds
-                - Upper bounds (np.ndarray): Upper confidence interval bounds
-        """
-        if quantiles is None:
-            quantiles = np.arange(1, 10) / 10
-        if np.any((quantiles <= 0) | (quantiles >= 1)):
-            raise ValueError("quantiles must be in the open interval (0, 1)")
-
-        qte = self._compute_qtes(
-            target_treatment_arm,
-            control_treatment_arm,
-            quantiles,
-            self.covariates,
-            self.treatment_arms,
-            self.outcomes,
-            self.strata,
-        )
-
-        # Precompute stratum indices for stratified bootstrap
-        unique_strata = np.unique(self.strata)
-        strata_indices = {s: np.where(self.strata == s)[0] for s in unique_strata}
-
-        qtes = np.zeros((n_bootstrap, qte.shape[0]))
-        bootstrap_iter = range(n_bootstrap)
-        if display_progress:
-            bootstrap_iter = tqdm(bootstrap_iter, desc="Bootstrap QTE")
-        for b in bootstrap_iter:
-            # Stratified bootstrap: resample within each stratum independently
-            bootstrap_indexes = np.concatenate([
-                np.random.choice(idx, size=len(idx), replace=True)
-                for idx in strata_indices.values()
-            ])
-
-            qtes[b] = self._compute_qtes(
-                target_treatment_arm,
-                control_treatment_arm,
-                quantiles,
-                self.covariates[bootstrap_indexes],
-                self.treatment_arms[bootstrap_indexes],
-                self.outcomes[bootstrap_indexes],
-                self.strata[bootstrap_indexes],
-            )
-
-        qte_var = qtes.var(axis=0)
-
-        qte_lower = qte + norm.ppf(alpha / 2) * np.sqrt(qte_var)
-        qte_upper = qte + norm.ppf(1 - alpha / 2) * np.sqrt(qte_var)
-
-        return qte, qte_lower, qte_upper
 
 
 class AdjustedStratifiedDistributionEstimator(DistributionEstimatorBase):
@@ -481,82 +404,6 @@ class AdjustedStratifiedDistributionEstimator(DistributionEstimatorBase):
                     superset_prediction[superset_mask, i] = pred
 
         return prediction.mean(axis=0), prediction, superset_prediction
-
-    def predict_qte(
-        self,
-        target_treatment_arm: int,
-        control_treatment_arm: int,
-        quantiles: Optional[np.ndarray] = None,
-        alpha: float = 0.05,
-        n_bootstrap=500,
-        display_progress: bool = True,
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """
-        Compute Quantile Treatment Effects (QTE) using stratified bootstrap.
-
-        Uses stratified bootstrap (resampling independently within each stratum) to
-        correctly estimate variance under covariate adaptive randomization (CAR).
-
-        Args:
-            target_treatment_arm (int): The index of the treatment arm of the treatment group.
-            control_treatment_arm (int): The index of the treatment arm of the control group.
-            quantiles (np.ndarray, optional): Quantiles used for QTE. Defaults to [0.1, 0.2, ..., 0.9].
-            alpha (float, optional): Significance level of the confidence bound. Defaults to 0.05.
-            n_bootstrap (int, optional): Number of bootstrap samples. Defaults to 500.
-            display_progress (bool, optional): Whether to display a progress bar. Defaults to True.
-
-        Returns:
-            Tuple[np.ndarray, np.ndarray, np.ndarray]: A tuple containing:
-                - Expected QTEs (np.ndarray): Treatment effect estimates at each quantile
-                - Lower bounds (np.ndarray): Lower confidence interval bounds
-                - Upper bounds (np.ndarray): Upper confidence interval bounds
-        """
-        if quantiles is None:
-            quantiles = np.arange(1, 10) / 10
-        if np.any((quantiles <= 0) | (quantiles >= 1)):
-            raise ValueError("quantiles must be in the open interval (0, 1)")
-
-        qte = self._compute_qtes(
-            target_treatment_arm,
-            control_treatment_arm,
-            quantiles,
-            self.covariates,
-            self.treatment_arms,
-            self.outcomes,
-            self.strata,
-        )
-
-        # Precompute stratum indices for stratified bootstrap
-        unique_strata = np.unique(self.strata)
-        strata_indices = {s: np.where(self.strata == s)[0] for s in unique_strata}
-
-        qtes = np.zeros((n_bootstrap, qte.shape[0]))
-        bootstrap_iter = range(n_bootstrap)
-        if display_progress:
-            bootstrap_iter = tqdm(bootstrap_iter, desc="Bootstrap QTE")
-        for b in bootstrap_iter:
-            # Stratified bootstrap: resample within each stratum independently
-            bootstrap_indexes = np.concatenate([
-                np.random.choice(idx, size=len(idx), replace=True)
-                for idx in strata_indices.values()
-            ])
-
-            qtes[b] = self._compute_qtes(
-                target_treatment_arm,
-                control_treatment_arm,
-                quantiles,
-                self.covariates[bootstrap_indexes],
-                self.treatment_arms[bootstrap_indexes],
-                self.outcomes[bootstrap_indexes],
-                self.strata[bootstrap_indexes],
-            )
-
-        qte_var = qtes.var(axis=0)
-
-        qte_lower = qte + norm.ppf(alpha / 2) * np.sqrt(qte_var)
-        qte_upper = qte + norm.ppf(1 - alpha / 2) * np.sqrt(qte_var)
-
-        return qte, qte_lower, qte_upper
 
     def _compute_model_prediction(self, model, covariates: np.ndarray) -> np.ndarray:
         if hasattr(model, "predict_proba"):

--- a/dte_adj/stratified.py
+++ b/dte_adj/stratified.py
@@ -183,6 +183,11 @@ class SimpleStratifiedDistributionEstimator(DistributionEstimatorBase):
                 - Lower bounds (np.ndarray): Lower confidence interval bounds
                 - Upper bounds (np.ndarray): Upper confidence interval bounds
         """
+        if quantiles is None:
+            quantiles = np.arange(1, 10) / 10
+        if np.any((quantiles <= 0) | (quantiles >= 1)):
+            raise ValueError("quantiles must be in the open interval (0, 1)")
+
         qte = self._compute_qtes(
             target_treatment_arm,
             control_treatment_arm,
@@ -506,6 +511,11 @@ class AdjustedStratifiedDistributionEstimator(DistributionEstimatorBase):
                 - Lower bounds (np.ndarray): Lower confidence interval bounds
                 - Upper bounds (np.ndarray): Upper confidence interval bounds
         """
+        if quantiles is None:
+            quantiles = np.arange(1, 10) / 10
+        if np.any((quantiles <= 0) | (quantiles >= 1)):
+            raise ValueError("quantiles must be in the open interval (0, 1)")
+
         qte = self._compute_qtes(
             target_treatment_arm,
             control_treatment_arm,

--- a/dte_adj/stratified.py
+++ b/dte_adj/stratified.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import numpy as np
-from typing import Tuple, Any
+from typing import Optional, Tuple, Any
 from copy import deepcopy
+from scipy.stats import norm
 from tqdm.auto import tqdm
 from dte_adj.base import DistributionEstimatorBase
 from dte_adj.util import ArrayLike, _convert_to_ndarray
@@ -152,6 +153,77 @@ class SimpleStratifiedDistributionEstimator(DistributionEstimatorBase):
             prediction[:, 1:] - prediction[:, :-1],
             conditional_prediction[:, 1:] - conditional_prediction[:, :-1],
         )
+
+    def predict_qte(
+        self,
+        target_treatment_arm: int,
+        control_treatment_arm: int,
+        quantiles: Optional[np.ndarray] = None,
+        alpha: float = 0.05,
+        n_bootstrap=500,
+        display_progress: bool = True,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Compute Quantile Treatment Effects (QTE) using stratified bootstrap.
+
+        Uses stratified bootstrap (resampling independently within each stratum) to
+        correctly estimate variance under covariate adaptive randomization (CAR).
+
+        Args:
+            target_treatment_arm (int): The index of the treatment arm of the treatment group.
+            control_treatment_arm (int): The index of the treatment arm of the control group.
+            quantiles (np.ndarray, optional): Quantiles used for QTE. Defaults to [0.1, 0.2, ..., 0.9].
+            alpha (float, optional): Significance level of the confidence bound. Defaults to 0.05.
+            n_bootstrap (int, optional): Number of bootstrap samples. Defaults to 500.
+            display_progress (bool, optional): Whether to display a progress bar. Defaults to True.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray, np.ndarray]: A tuple containing:
+                - Expected QTEs (np.ndarray): Treatment effect estimates at each quantile
+                - Lower bounds (np.ndarray): Lower confidence interval bounds
+                - Upper bounds (np.ndarray): Upper confidence interval bounds
+        """
+        qte = self._compute_qtes(
+            target_treatment_arm,
+            control_treatment_arm,
+            quantiles,
+            self.covariates,
+            self.treatment_arms,
+            self.outcomes,
+            self.strata,
+        )
+
+        # Precompute stratum indices for stratified bootstrap
+        unique_strata = np.unique(self.strata)
+        strata_indices = {s: np.where(self.strata == s)[0] for s in unique_strata}
+
+        qtes = np.zeros((n_bootstrap, qte.shape[0]))
+        bootstrap_iter = range(n_bootstrap)
+        if display_progress:
+            bootstrap_iter = tqdm(bootstrap_iter, desc="Bootstrap QTE")
+        for b in bootstrap_iter:
+            # Stratified bootstrap: resample within each stratum independently
+            bootstrap_indexes = np.concatenate([
+                np.random.choice(idx, size=len(idx), replace=True)
+                for idx in strata_indices.values()
+            ])
+
+            qtes[b] = self._compute_qtes(
+                target_treatment_arm,
+                control_treatment_arm,
+                quantiles,
+                self.covariates[bootstrap_indexes],
+                self.treatment_arms[bootstrap_indexes],
+                self.outcomes[bootstrap_indexes],
+                self.strata[bootstrap_indexes],
+            )
+
+        qte_var = qtes.var(axis=0)
+
+        qte_lower = qte + norm.ppf(alpha / 2) * np.sqrt(qte_var)
+        qte_upper = qte + norm.ppf(1 - alpha / 2) * np.sqrt(qte_var)
+
+        return qte, qte_lower, qte_upper
 
 
 class AdjustedStratifiedDistributionEstimator(DistributionEstimatorBase):
@@ -404,6 +476,77 @@ class AdjustedStratifiedDistributionEstimator(DistributionEstimatorBase):
                     superset_prediction[superset_mask, i] = pred
 
         return prediction.mean(axis=0), prediction, superset_prediction
+
+    def predict_qte(
+        self,
+        target_treatment_arm: int,
+        control_treatment_arm: int,
+        quantiles: Optional[np.ndarray] = None,
+        alpha: float = 0.05,
+        n_bootstrap=500,
+        display_progress: bool = True,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Compute Quantile Treatment Effects (QTE) using stratified bootstrap.
+
+        Uses stratified bootstrap (resampling independently within each stratum) to
+        correctly estimate variance under covariate adaptive randomization (CAR).
+
+        Args:
+            target_treatment_arm (int): The index of the treatment arm of the treatment group.
+            control_treatment_arm (int): The index of the treatment arm of the control group.
+            quantiles (np.ndarray, optional): Quantiles used for QTE. Defaults to [0.1, 0.2, ..., 0.9].
+            alpha (float, optional): Significance level of the confidence bound. Defaults to 0.05.
+            n_bootstrap (int, optional): Number of bootstrap samples. Defaults to 500.
+            display_progress (bool, optional): Whether to display a progress bar. Defaults to True.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray, np.ndarray]: A tuple containing:
+                - Expected QTEs (np.ndarray): Treatment effect estimates at each quantile
+                - Lower bounds (np.ndarray): Lower confidence interval bounds
+                - Upper bounds (np.ndarray): Upper confidence interval bounds
+        """
+        qte = self._compute_qtes(
+            target_treatment_arm,
+            control_treatment_arm,
+            quantiles,
+            self.covariates,
+            self.treatment_arms,
+            self.outcomes,
+            self.strata,
+        )
+
+        # Precompute stratum indices for stratified bootstrap
+        unique_strata = np.unique(self.strata)
+        strata_indices = {s: np.where(self.strata == s)[0] for s in unique_strata}
+
+        qtes = np.zeros((n_bootstrap, qte.shape[0]))
+        bootstrap_iter = range(n_bootstrap)
+        if display_progress:
+            bootstrap_iter = tqdm(bootstrap_iter, desc="Bootstrap QTE")
+        for b in bootstrap_iter:
+            # Stratified bootstrap: resample within each stratum independently
+            bootstrap_indexes = np.concatenate([
+                np.random.choice(idx, size=len(idx), replace=True)
+                for idx in strata_indices.values()
+            ])
+
+            qtes[b] = self._compute_qtes(
+                target_treatment_arm,
+                control_treatment_arm,
+                quantiles,
+                self.covariates[bootstrap_indexes],
+                self.treatment_arms[bootstrap_indexes],
+                self.outcomes[bootstrap_indexes],
+                self.strata[bootstrap_indexes],
+            )
+
+        qte_var = qtes.var(axis=0)
+
+        qte_lower = qte + norm.ppf(alpha / 2) * np.sqrt(qte_var)
+        qte_upper = qte + norm.ppf(1 - alpha / 2) * np.sqrt(qte_var)
+
+        return qte, qte_lower, qte_upper
 
     def _compute_model_prediction(self, model, covariates: np.ndarray) -> np.ndarray:
         if hasattr(model, "predict_proba"):

--- a/tests/test_stratified_estimators.py
+++ b/tests/test_stratified_estimators.py
@@ -214,3 +214,67 @@ class TestStratifiedEstimators(unittest.TestCase):
         width_010 = upper_010 - lower_010
 
         self.assertTrue(np.all(width_010 < width_005))
+
+    def test_predict_qte_preserves_per_stratum_counts(self):
+        # Stratified bootstrap must preserve per-stratum sample counts in every
+        # bootstrap replicate. This would fail under a plain (unstratified) bootstrap.
+        estimator = SimpleStratifiedDistributionEstimator()
+        estimator.fit(self.X, self.W, self.Y, self.strata)
+
+        original_counts = np.bincount(self.strata.astype(int))
+
+        captured_strata = []
+        original_compute = estimator._compute_qtes
+
+        def spy_compute(*args, **kwargs):
+            captured_strata.append(args[-1])
+            return original_compute(*args, **kwargs)
+
+        estimator._compute_qtes = spy_compute
+        try:
+            estimator.predict_qte(
+                target_treatment_arm=1,
+                control_treatment_arm=0,
+                quantiles=np.array([0.5]),
+                n_bootstrap=5,
+                display_progress=False,
+            )
+        finally:
+            estimator._compute_qtes = original_compute
+
+        # 1 call for the point estimate + 5 bootstrap calls
+        self.assertEqual(len(captured_strata), 6)
+        for strata in captured_strata:
+            np.testing.assert_array_equal(
+                np.bincount(strata.astype(int)), original_counts
+            )
+
+    def test_predict_qte_default_quantiles(self):
+        # quantiles=None should default to [0.1, 0.2, ..., 0.9] without erroring.
+        estimator = SimpleStratifiedDistributionEstimator()
+        estimator.fit(self.X, self.W, self.Y, self.strata)
+
+        qte, lower, upper = estimator.predict_qte(
+            target_treatment_arm=1,
+            control_treatment_arm=0,
+            n_bootstrap=10,
+            display_progress=False,
+        )
+
+        self.assertEqual(qte.shape, (9,))
+        self.assertEqual(lower.shape, (9,))
+        self.assertEqual(upper.shape, (9,))
+        self.assertTrue(np.all(lower <= upper))
+
+    def test_predict_qte_rejects_out_of_range_quantiles(self):
+        estimator = SimpleStratifiedDistributionEstimator()
+        estimator.fit(self.X, self.W, self.Y, self.strata)
+
+        with self.assertRaises(ValueError):
+            estimator.predict_qte(
+                1, 0, quantiles=np.array([0.0, 0.5]), n_bootstrap=5, display_progress=False
+            )
+        with self.assertRaises(ValueError):
+            estimator.predict_qte(
+                1, 0, quantiles=np.array([0.5, 1.0]), n_bootstrap=5, display_progress=False
+            )


### PR DESCRIPTION
Implement predict_qte in SimpleStratifiedDistributionEstimator and AdjustedStratifiedDistributionEstimator with stratified bootstrap (resampling within each stratum independently) to correctly estimate variance under CAR designs.

close #64 