### PR TITLE
Add missing DOIs to bibliography per JOSS reference check

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,11 +1,13 @@
-@misc{byambadalai2024estimatingdistributionaltreatmenteffects,
+@inproceedings{byambadalai2024estimatingdistributionaltreatmenteffects,
       title={Estimating Distributional Treatment Effects in Randomized Experiments: Machine Learning for Variance Reduction},
-      author={Undral Byambadalai and Tatsushi Oka and Shota Yasui},
+      author={Byambadalai, Undral and Oka, Tatsushi and Yasui, Shota},
+      booktitle={Proceedings of the 41st International Conference on Machine Learning},
+      pages={5082--5113},
       year={2024},
-      eprint={2407.16037},
-      archivePrefix={arXiv},
-      primaryClass={econ.EM},
-      url={https://arxiv.org/abs/2407.16037},
+      volume={235},
+      series={Proceedings of Machine Learning Research},
+      publisher={PMLR},
+      doi={10.2139/ssrn.4910058}
 }
 
 @book{fisher1935design,
@@ -50,31 +52,31 @@
 
 @inproceedings{byambadalai2025efficientestimationdistributionaltreatment,
       title={On Efficient Estimation of Distributional Treatment Effects under Covariate-Adaptive Randomization},
-      author={Undral Byambadalai and Tomu Hirata and Tatsushi Oka and Shota Yasui},
+      author={Byambadalai, Undral and Hirata, Tomu and Oka, Tatsushi and Yasui, Shota},
       booktitle={Proceedings of the 42nd International Conference on Machine Learning},
       year={2025},
-      series={ICML'25},
-      url={https://arxiv.org/abs/2506.05945}
+      series={Proceedings of Machine Learning Research},
+      publisher={PMLR},
+      doi={10.2139/ssrn.5286083}
 }
 
 @misc{hirata2025efficientscalableestimationdistributional,
       title={Efficient and Scalable Estimation of Distributional Treatment Effects with Multi-Task Neural Networks},
-      author={Tomu Hirata and Undral Byambadalai and Tatsushi Oka and Shota Yasui and Shunsuke Uto},
+      author={Hirata, Tomu and Byambadalai, Undral and Oka, Tatsushi and Yasui, Shota and Uto, Shunsuke},
       year={2025},
       eprint={2507.07738},
       archivePrefix={arXiv},
       primaryClass={econ.EM},
-      url={https://arxiv.org/abs/2507.07738}
+      url={https://arxiv.org/abs/2507.07738},
+      doi={10.2139/ssrn.5347645}
 }
 
-@misc{byambadalai2025imperfectcompliance,
+@inproceedings{byambadalai2025imperfectcompliance,
       title={Beyond the Average: Distributional Causal Inference under Imperfect Compliance},
-      author={Undral Byambadalai and Tomu Hirata and Tatsushi Oka and Shota Yasui},
+      author={Byambadalai, Undral and Hirata, Tomu and Oka, Tatsushi and Yasui, Shota},
+      booktitle={Advances in Neural Information Processing Systems},
       year={2025},
-      eprint={2509.15594},
-      archivePrefix={arXiv},
-      primaryClass={econ.EM},
-      url={https://arxiv.org/abs/2509.15594}
+      doi={10.2139/ssrn.5504858}
 }
 
 @article{oka2025regression,
@@ -98,7 +100,7 @@
   author={Sharma, Amit and Kiciman, Emre},
   journal={arXiv preprint arXiv:2011.04216},
   year={2020},
-  url={https://arxiv.org/abs/2011.04216}
+  doi={10.48550/arXiv.2011.04216}
 }
 
 @inproceedings{econml,
@@ -107,7 +109,8 @@
   booktitle={Proceedings of the 27th ACM SIGKDD Conference on Knowledge Discovery \& Data Mining},
   pages={4072--4073},
   year={2021},
-  organization={ACM}
+  organization={ACM},
+  doi={10.1145/3447548.3470792}
 }
 
 @ARTICLE{2020SciPy-NMeth,


### PR DESCRIPTION
## Summary
Added missing DOIs

**MISSING DOIs (added):**
- Byambadalai et al. 2024 (ICML): `10.2139/ssrn.4910058`
- Byambadalai et al. 2025 (ICML): `10.2139/ssrn.5286083`
- Hirata et al. 2025 (arXiv): `10.2139/ssrn.5347645`
- Byambadalai et al. 2025 (NeurIPS): `10.2139/ssrn.5504858`

**SKIP DOIs (added where available):**
- DoWhy: `10.48550/arXiv.2011.04216`
- EconML (KDD 2021): `10.1145/3447548.3470792`

**Remaining SKIP entries (no DOIs available):**
- Fisher 1935 — pre-DOI era book
- Scikit-learn — JMLR does not assign DOIs
- Hillstrom 2008 — blog post