### PR TITLE
fix(docs): cast strata to str before replace in Oregon tutorial

### DIFF
--- a/docs/source/tutorials/oregon.rst
+++ b/docs/source/tutorials/oregon.rst
@@ -80,7 +80,7 @@ Next, we prepare the data for the DTE analysis. This involves creating treatment
 
     # Create strata based on household size
     df.rename(columns={'numhh_list': 'strata'}, inplace=True)
-    df['strata'] = df['strata'].replace({
+    df['strata'] = df['strata'].astype(str).replace({
         'signed self up + 1 additional person': 'signed self up + others',
         'signed self up + 2 additional people': 'signed self up + others'
     })


### PR DESCRIPTION
## Summary

The Oregon tutorial's preprocessing step calls `.replace()` directly on the `strata` column (renamed from `numhh_list`). Since `numhh_list` is a pandas categorical column, mapping its values to `'signed self up + others'` (a category that does not exist) raises a type error.

This adds `.astype(str)` before `.replace()` so the column is converted to a string type first, avoiding the error.

## Changes

```python
df['strata'] = df['strata'].astype(str).replace({
    'signed self up + 1 additional person': 'signed self up + others',
    'signed self up + 2 additional people': 'signed self up + others'
})
```