### PR TITLE
Fix predict() docstring to label argument as locations

### DIFF
--- a/dte_adj/base.py
+++ b/dte_adj/base.py
@@ -424,7 +424,7 @@ class DistributionEstimatorBase(ABC):
 
         Args:
             treatment_arm (int): The index of the treatment arm.
-            outcomes (np.ndarray): Scalar values to be used for computing the cumulative distribution.
+            locations (np.ndarray): Scalar values to be used for computing the cumulative distribution.
             display_progress (bool, optional): Whether to display a progress bar. Defaults to True.
 
         Returns:


### PR DESCRIPTION
## Summary
- Fix docstring for `DistributionEstimatorBase.predict()` in `dte_adj/base.py`, which labelled its `locations` argument as `outcomes`. Because `predict()` is inherited by all estimators (e.g., `SimpleStratifiedDistributionEstimator`), the mislabeled arg surfaced in their docs too.

## Test plan
- [x] Pre-commit hooks (ruff lint/format) pass
- [ ] Sphinx docs build cleanly