### PR TITLE
chore: bump version to 0.1.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dte_adj"
-version = "0.1.9"
+version = "0.1.10"
 description = "This is a Python library for estimating distributional treatment effects"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump `version` in `pyproject.toml` from `0.1.9` to `0.1.10`.

## Why
Version 0.1.9 is already published on PyPI, so the release workflow ([run 32277374005](https://github.com/CyberAgentAILab/python-dte-adjustment/actions/runs/32277374005/job/96319622526)) failed with `400 Bad Request` when `twine upload` tried to re-upload the same version. PyPI treats versions as immutable, so we need a new version number.

## Test plan
- [ ] After merge, create a new GitHub release and confirm the publish workflow uploads `dte_adj-0.1.10` successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)