### PR TITLE
docs: remove contributing page

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -1,3 +1,0 @@
-# Contribution Guide
-
-Regarding how to contribute to this package, please refer to [CONTRIBUTING.md](https://github.com/CyberAgentAILab/python-dte-adjustment/blob/main/CONTRIBUTING.md) for more details.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -52,7 +52,6 @@ nav:
       - Covariate Adaptive Randomization: api/stratified.md
       - Local Distribution: api/local.md
       - Plotting: api/plot.md
-  - Contributing: contributing.md
 
 plugins:
   - search


### PR DESCRIPTION
## Summary

Removes `docs/docs/contributing.md` and its nav entry from `mkdocs.yml`. The page was a one-liner pointing at [CONTRIBUTING.md](https://github.com/CyberAgentAILab/python-dte-adjustment/blob/main/CONTRIBUTING.md) on GitHub — the repo link in the site header already surfaces that, so a standalone page adds no value.

## Test plan

- [x] `mkdocs build --strict` passes locally
- [ ] Verify the Contributing entry is gone from the site nav after deploy