### PR TITLE
docs: drop .html suffix from get-started URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     ```
 
 ## Basic Usage
-Examples of how to use this package are available in [this Get-started Guide](https://cyberagentailab.github.io/python-dte-adjustment/get_started.html).
+Examples of how to use this package are available in [this Get-started Guide](https://cyberagentailab.github.io/python-dte-adjustment/get_started/).
 
 ## Theoretical Foundations
 


### PR DESCRIPTION
Post-MkDocs migration audit: the README still linked to the get-started page with a Sphinx-style .html suffix. MkDocs serves pages under directory-style URLs, so the link now points to `.../get_started/` to match.

## Test plan
- [x] `grep -r '\.html' --include='*.md' --include='*.py'` shows no remaining doc URLs with the .html suffix in the repo (build/ and .venv/ excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)